### PR TITLE
Fix #3 by updating requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ more-itertools==8.5.0
 numpy==1.26.2
 packaging==21.3
 pandas==2.1.2
-patsy==0.5.2
+patsy==0.5.4
 pluggy==0.13.1
 py==1.9.0
 pyparsing==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,20 +3,20 @@ coverage==5.2.1
 importlib-metadata==1.7.0
 iniconfig==1.0.1
 more-itertools==8.5.0
-numpy==1.19.1
-packaging==20.4
-pandas==1.1.1
-patsy==0.5.1
+numpy==1.26.2
+packaging==21.3
+pandas==2.1.2
+patsy==0.5.2
 pluggy==0.13.1
 py==1.9.0
 pyparsing==2.4.7
 pytest==6.0.1
 pytest-cov==2.10.1
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 pytz==2020.1
-scipy==1.5.2
+# scipy==1.5.2
 six==1.15.0
-statsmodels==0.12.0
+statsmodels==0.14.0
 toml==0.10.1
 wget==3.2
 zipp==3.1.0


### PR DESCRIPTION
This updates requirements.txt so that numpy and other packages install OK on a machine with a recent Cython.

Obviously, no guarantee it doesn't break something else, but it *seems* to work for me.